### PR TITLE
Wait until the animation has been loaded into DOM

### DIFF
--- a/projects/lottie/src/lib/lottie.component.ts
+++ b/projects/lottie/src/lib/lottie.component.ts
@@ -57,7 +57,9 @@ export class LottieComponent implements OnInit {
     this.viewWidth = this.width + 'px' || '100%';
     this.viewHeight = this.height + 'px' || '100%';
 
-    this.animationCreated.emit(animation);
+    animation.addEventListener('DOMLoaded', () => {
+      this.animationCreated.emit(animation);
+    });
   }
 
 }


### PR DESCRIPTION
Wait until the animation has been loaded into DOM. If you emit the event before the animation has been loaded into the DOM, the object is missing crucial values such as `totalFrames` (i.e., 0 instead of n frames).